### PR TITLE
In GameActivity show a fullscreen textView while the product is loading

### DIFF
--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/GameActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/GameActivity.kt
@@ -9,6 +9,7 @@ import android.os.CountDownTimer
 import android.os.Handler
 import android.os.Looper
 import android.util.TypedValue
+import android.view.View
 import android.widget.Toast
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
@@ -20,6 +21,7 @@ import ar.teamrocket.duelosmeli.databinding.ActivityGameBinding
 import ar.teamrocket.duelosmeli.domain.Game
 import ar.teamrocket.duelosmeli.domain.GameFunctions
 import ar.teamrocket.duelosmeli.ui.singleplayerActivities.viewModels.GameViewModel
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import retrofit2.HttpException
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -56,12 +58,16 @@ class GameActivity : AppCompatActivity() {
     }
 
     private fun continueGame(){
+        binding.clLoading.visibility=View.VISIBLE
         vm.findCategories()
     }
 
     private fun setListeners(){
         vm.starGame.observe(this, {
-            if (it) vm.findCategories()
+            if (it) {
+                binding.clLoading.visibility=View.VISIBLE
+                vm.findCategories()
+            }
         })
     }
 
@@ -75,9 +81,18 @@ class GameActivity : AppCompatActivity() {
             if (it != null){
                 Picasso.get()
                     .load(it)
-                    .placeholder(R.drawable.spinner)
+                    .noFade()
                     .error(R.drawable.no_image)
-                    .into(binding.ivProductPicture)
+                    .into(binding.ivProductPicture, object: Callback {
+                        override fun onSuccess() {
+                            //mostrar pantalla del juego
+                            binding.clLoading.visibility=View.GONE
+                        }
+
+                        override fun onError(e: java.lang.Exception?) {
+                            //do smth when there is picture loading error
+                        }
+                    })
             }
         })
         vm.randomNumber1to3Mutable.observe(this, {
@@ -114,10 +129,6 @@ class GameActivity : AppCompatActivity() {
         vm.categoriesException.observe(this, this::handleException)
         vm.itemFromCategoryException.observe(this, this::handleException)
         vm.itemException.observe(this, this::handleException)
-        // Para probar un snackbar y ver diferencia con Toast
-        /*vm.itemException.observe(this, {
-            Snackbar.make(binding.root, it.toString(), Snackbar.LENGTH_LONG).show()
-        })*/
     }
 
     private fun handleException(exception: Throwable?) {
@@ -145,14 +156,14 @@ class GameActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
-    
+
     private fun successChecker(correctOption: Int, game: Game) {
         startTimer(game, correctOption)
     }
 
     private fun startTimer(game: Game, correctOption: Int) {
         countDownTimer = object : CountDownTimer(timer,1000){
-            //            end of timer
+
             override fun onFinish() {
                 when (correctOption) {
                     1 -> oneCorrect()
@@ -170,6 +181,7 @@ class GameActivity : AppCompatActivity() {
         }.start()
         optionsButtons(game, correctOption)
     }
+
     private fun pauseTimer() {
         countDownTimer.cancel()
     }
@@ -177,9 +189,7 @@ class GameActivity : AppCompatActivity() {
     private fun setTextTimer() {
         val m = (timer / 1000) / 60
         val s = (timer / 1000) % 60
-
         val format = String.format("%02d:%02d", m, s)
-
         binding.tvTime.text = format
     }
 
@@ -248,7 +258,7 @@ class GameActivity : AppCompatActivity() {
         binding.btnOption2.setBackgroundColor(ResourcesCompat.getColor(resources, R.color.red,null))
         binding.btnOption3.setBackgroundColor(ResourcesCompat.getColor(resources, R.color.green,null))
     }
-    
+
 
     private fun colorResetter(){
         binding.btnOption1.setBackgroundColor(getColorFromAttr(R.attr.colorPrimary))

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -6,17 +6,24 @@
     android:layout_height="match_parent"
     tools:context=".ui.singleplayerActivities.views.GameActivity">
 
-    <androidx.core.widget.NestedScrollView
+    <ScrollView
+        android:id="@+id/svScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true"
-        tools:layout_editor_absoluteX="0dp"
-        tools:layout_editor_absoluteY="0dp">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingBottom="20dp">
+            android:layout_height="wrap_content"
+
+            android:paddingBottom="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/tvQuestion"
@@ -62,7 +69,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tvProductName"
-                tools:text="Opción 1"/>
+                tools:text="Opción 1" />
 
             <Button
                 android:id="@+id/btnOption3"
@@ -75,7 +82,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnOption2"
-                tools:text="Opción 3"/>
+                tools:text="Opción 3" />
 
             <Button
                 android:id="@+id/btnOption2"
@@ -88,7 +95,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnOption1"
-                tools:text="Opción 2"/>
+                tools:text="Opción 2" />
 
             <ImageView
                 android:id="@+id/ivProductPicture"
@@ -130,8 +137,7 @@
                 app:layout_constraintStart_toEndOf="@+id/ivLifeOne"
                 app:layout_constraintTop_toTopOf="@+id/ivLifeOne"
                 app:srcCompat="@drawable/ic_life_filled"
-                tools:ignore="ContentDescription"
-                />
+                tools:ignore="ContentDescription" />
 
             <ImageView
                 android:id="@+id/ivLifeThree"
@@ -143,7 +149,31 @@
                 tools:ignore="ContentDescription" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 
-    </androidx.core.widget.NestedScrollView>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clLoading"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/blue"
+            android:gravity="center"
+            android:text="¿Estás listo?"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+            android:textColor="#FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Al jugar en modo SinglePlayer, muestra un textView de pantalla completa que tapa los demás views para que se puedan cargar los datos sin que el usuario los vea. 
Una vez que la imagen del producto esta cargada, el textView desaparece para que el usuario pueda jugar.

En este ticket sólo se crea la funcionalidad. El diseño se mejorará en otra oportunidad.