### PR TITLE
Feature/permission camera

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,10 @@ android {
 }
 
 dependencies {
-    def room_version = "2.3.0"
+    def room_version = '2.4.2'
+    def koin_version = '3.2.0'
+    def camerax_version = "1.2.0-alpha01"
+
 
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
@@ -45,24 +48,31 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
 
     // Room
+    kapt "androidx.room:room-compiler:${room_version}"
     implementation "androidx.room:room-common:${room_version}"
     implementation "androidx.room:room-runtime:${room_version}"
     implementation "androidx.room:room-ktx:${room_version}"
-    kapt "androidx.room:room-compiler:${room_version}"
+
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.12.0'
+
     // Picasso
     implementation 'com.squareup.picasso:picasso:2.71828'
+
     // GSON
     implementation 'com.squareup.retrofit2:converter-gson:2.6.2'
+
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.6.2'
+    
     // ViewModel
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.activity:activity-ktx:1.3.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
+
     // LiveData
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
-    // Corrutines
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.1'
+
+    // Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
 
     implementation 'com.android.databinding:viewbinding:4.0.1'
@@ -72,19 +82,17 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     //Koin
-    implementation 'io.insert-koin:koin-android:3.1.2'
-    implementation 'io.insert-koin:koin-android-compat:3.1.2'
-    implementation 'io.insert-koin:koin-androidx-workmanager:3.1.2'
-    implementation 'io.insert-koin:koin-androidx-compose:3.1.2'
+    implementation "io.insert-koin:koin-android:${koin_version}"
+    implementation "io.insert-koin:koin-android-compat:${koin_version}"
+    implementation "io.insert-koin:koin-androidx-workmanager:${koin_version}"
+    implementation "io.insert-koin:koin-androidx-compose:${koin_version}"
 
     //Permission
-    implementation "androidx.activity:activity-ktx:1.2.0-beta01"
-    implementation "androidx.fragment:fragment-ktx:1.3.0-beta01"
-
+    implementation "androidx.activity:activity-ktx:1.6.0-alpha04"
+    implementation "androidx.fragment:fragment-ktx:1.5.0-rc01"
 
     //Camera
     // CameraX core library using the camera2 implementation
-    def camerax_version = "1.1.0-beta02"
     // The following line is optional, as the core library is included indirectly by camera-camera2
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    compileSdk 31
 
     defaultConfig {
         applicationId "ar.teamrocket.duelosmeli"
-        minSdk 23
-        targetSdk 30
+        minSdk 31
+        targetSdk 31
         versionCode 1
         versionName "1.0"
 
@@ -37,15 +37,16 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.room:room-common:2.3.0'
     def room_version = "2.3.0"
 
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+
     // Room
-    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-common:${room_version}"
+    implementation "androidx.room:room-runtime:${room_version}"
     implementation "androidx.room:room-ktx:${room_version}"
     kapt "androidx.room:room-compiler:${room_version}"
     // Glide


### PR DESCRIPTION
Android X Camera necesita que la versión mínima de la SDK sea la 31. Es por eso que hace falta incrementar la versión de la SDK objetivo y mínima a dicha versión para que pueda compilar.

También se actualiza KOIN a la versión 3.2 que arregla unos problemas de compatibilidad con kotlin 1.6.0

https://github.com/InsertKoinIO/koin/issues/1188