### PR TITLE
[Feature] Intent to Mercado Libre (app or web)

### DIFF
--- a/app/src/main/java/ar/teamrocket/duelosmeli/data/model/Article.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/data/model/Article.kt
@@ -7,7 +7,8 @@ data class Article (
     var title: String,
     var thumbnail: String,
     var pictures: List<ArticlePicture>,
-    var price: Double
+    var price: Double,
+    var permalink: String
 )
 
 data class ArticlePicture (

--- a/app/src/main/java/ar/teamrocket/duelosmeli/data/model/ItemPlayed.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/data/model/ItemPlayed.kt
@@ -7,5 +7,5 @@ import kotlinx.parcelize.Parcelize
 data class ItemPlayed (
     var title: String,
     var picture: String,
-    var link: String
+    var permalink: String
 ): Parcelable

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
@@ -89,10 +89,10 @@ class ListActivity : ComponentActivity() {
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable {
-
-                            //TODO abrir la publicación en Mercado Libre
-                            // itemPlayed.link
-
+                            /**
+                             * Se abre la publicación en la app de Mercado Libre en caso de tenerla
+                             * instalada, y sinó abre la publicación en el navegador web.
+                             */
                             val intent: Intent = Uri.parse(itemPlayed.permalink).let {
                                 Intent(Intent.ACTION_VIEW, it)
                             }

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
@@ -1,5 +1,7 @@
 package ar.teamrocket.duelosmeli.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -91,6 +93,10 @@ class ListActivity : ComponentActivity() {
                             //TODO abrir la publicación en Mercado Libre
                             // itemPlayed.link
 
+                            val intent: Intent = Uri.parse(itemPlayed.permalink).let {
+                                Intent(Intent.ACTION_VIEW, it)
+                            }
+                            startActivity(intent)
                         }
                 )
             }

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/GameViewModel.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/GameViewModel.kt
@@ -112,6 +112,7 @@ class GameViewModel (val meliRepositoryImpl : MeliRepository, private val prefs:
                 val item = itemsList[(itemsList.indices).random()]
                 itemNameMutable.value = item.title
                 itemPlayed.title = item.title
+                itemPlayed.permalink = item.permalink
 
                 itemPriceString.value = numberRounder(item.price)
                 Log.d("ITEM_ID","ITEM: ${item.id} CATEGORY: $categoryId")


### PR DESCRIPTION
Se agregó un **webIntent** que nos permite visualizar cualquiera de los artículos listados al final de la partida (en el modo de juego SinglePlayer) en la app de Mercado Libre, en caso de que esté instalada en el dispositivo, y sinó en el navegador web predeterminado.

- Al model de 'Article' que es el que usamos originalmente con la API para modelar los datos de cada artículo le agregué la propiedad "permalink", que está en la documentación para cada producto, y este **string** es link del producto.
- Al modelado del ItemPlayed le renombré la propiedad "link" por "permalink" para que esté todo alineado a como viene el dato desde la API.
- Y en el 'GameViewModel' simplemente le agregué al 'itemPlayed' el "permalink" de la misma forma que ya se guardaba el "title" y la "picture".

El webIntent resultó suficiente para cubrir lo que necesitamos de la feature.

En el video se ve el flujo dirigiéndose a la app de Mercado Libre, no hice video para cuando va al navegador pero lo pude checkear desde el emulador en Android Studio y funciona sin problemas.

P.D.: ya le estamos regalando potenciales compradores a Mercado Libre 🤑 💸 💰 💵 

https://user-images.githubusercontent.com/49699988/177080071-6810a59a-804c-486f-9ebc-1e843af10953.mp4

.