### PR TITLE
[Fix] Opening sound bad reproduction

### DIFF
--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/HomeActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/HomeActivity.kt
@@ -21,16 +21,20 @@ class HomeActivity : AppCompatActivity() {
         setContentView(binding.root)
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
 
-        // Reproducción del sonido de apertura de la app
-        openingSound = MediaPlayer.create(this, R.raw.open)
-        openingSound.setOnPreparedListener {
-            openingSound.start()
-        }
 
         // Se instancia una clase que implementa una interfaz con funciones para esta Activity
         homeFunctions.showImage(this, R.drawable.animated_logo, binding.ivLogo)
         homeFunctions.showImage(this, R.drawable.duelosmeli, binding.ivTitle)
         binding.btnPlayGame.setOnClickListener { viewMainMenu() }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Reproducción del sonido de apertura de la app
+        openingSound = MediaPlayer.create(this, R.raw.open)
+        openingSound.setOnPreparedListener {
+            openingSound.start()
+        }
     }
 
     private fun viewMainMenu() {


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios -->
Fix del bug del opening sound.

## Motivación y contexto
<!--- Motivo del cambio. ¿Qué problema resuelve? -->

- El opening sound se reproducía 2 veces al momento de abrir/ejecutar la app.
- Al hacer back desde 'MainMenuActivity' no se reproducía el sonido.
- Al volver desde background no se reproducía el sonido.

## Descripción
<!--- Describir los cambios en detalle -->
El código encargado de la reproducción del sonido estaba en el onCreate() y esa era la causa del bug.
No corresponde que se reproduzca el sonido al momento en que se crea la activity, sino que más bien es una función que se debe ejecutar una vez que la activity ya fue creada.
Se solucionó cambiando de lugar el código según el ciclo de vida.
El cambio específicamente fue sacar el código del onCreate() y meterlo en el onResume(). De esta forma nos aseguramos de que el sonido se reproduce una vez que la activity fue creada.

## Cómo probarlo
<!--- Bug fixes: describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Nuevos features: describir qué función de la app probar -->
Tenemos 3 flujos para probar según lo dicho en "Motivación y contexto"
1. Abrir la aplicación
2. Abrir la aplicación, ir a background y volver.
3. Abrir la aplicación, tocar en "Jugar" y hacer back.
