### PR TITLE
[Feature] Screen stays on during gameplay

### DIFF
--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/duelActivities/DuelActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/duelActivities/DuelActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
+import android.view.WindowManager
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
@@ -38,6 +39,8 @@ class DuelActivity : AppCompatActivity() {
         binding = ActivityDuelBinding.inflate(layoutInflater)
         setContentView(binding.root)
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
         val gson = Gson()
         val itemsString = intent.getStringExtra("ITEMS")
         val itemsType = object : TypeToken<MutableList<ItemDuel>>() {}.type

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/multiplayerActivities/view/MultiplayerGameActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/multiplayerActivities/view/MultiplayerGameActivity.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.CountDownTimer
+import android.view.WindowManager
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatDelegate
 import ar.teamrocket.duelosmeli.ui.MainMenuActivity
 import ar.teamrocket.duelosmeli.R
 import ar.teamrocket.duelosmeli.databinding.ActivityMultiplayerGameBinding
@@ -26,6 +28,8 @@ class MultiplayerGameActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMultiplayerGameBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         val game = intent.extras!!.getParcelable<GameMultiplayer>("Game")!!
         vm.setGame(game)

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/GameActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/GameActivity.kt
@@ -11,10 +11,12 @@ import android.os.*
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
+import android.view.WindowManager
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.res.ResourcesCompat
 import ar.teamrocket.duelosmeli.R
 import ar.teamrocket.duelosmeli.data.database.PlayerDao
@@ -56,6 +58,9 @@ class GameActivity : AppCompatActivity(), SensorEventListener {
         super.onCreate(savedInstanceState)
         binding = ActivityGameBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
         listPlayedItems = mutableListOf()
 
         binding.iHeader.tvTitle.text = getString(R.string.whats_the_price)


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios -->
Se agregó la flag "FLAG_KEEP_SCREEN_ON" en las game activities para mantener la pantalla siempre encendida durante el juego.

De paso, agregué la FLAG "MODE_NIGHT_NO" en esas game activities, porque al forzar la finalizacion de las partidas se me pasaba la app al modo noche, 

Documentacion usada:
https://developer.android.com/training/scheduling/wakelock?hl=es-419#screen