### PR TITLE
[Feature] Category search decoupling

### DIFF
--- a/app/src/main/java/ar/teamrocket/duelosmeli/HttpStatusHandler.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/HttpStatusHandler.kt
@@ -1,0 +1,18 @@
+package ar.teamrocket.duelosmeli
+
+import android.util.Log
+import retrofit2.HttpException
+
+/**
+ * Función de nivel superior. Puede ser usada en cualquier parte del código.
+ * La idea es poder handlear los codigos de status HTTP. Por el momento los dejamos con Logs.
+ */
+fun httpStatusHandler(e: HttpException) {
+    when (e.code()) {
+        in 100..199 -> Log.i("Informational", "Status code ${e.code()}. Response: ${e.response()}")
+        in 200..299 -> Log.i("Success", "Status code ${e.code()}. Response: ${e.response()}")
+        in 300..399 -> Log.i("Redirection", "Status code ${e.code()}. Response: ${e.response()}")
+        in 400..499 -> Log.i("Client Error", "Status code ${e.code()}. Response: ${e.response()}")
+        in 500..599 -> Log.i("Server Error", "Status code ${e.code()}. Response: ${e.response()}")
+    }
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/InternetConnectionChecker.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/InternetConnectionChecker.kt
@@ -1,0 +1,17 @@
+package ar.teamrocket.duelosmeli
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/**
+ * Esta función permite verificar si el dispositivo cuenta con conexión a internet.
+ */
+fun isInternetAvailable(context: Context): Boolean {
+    val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    val network = connectivityManager.activeNetwork
+    val networkCapabilities = connectivityManager.getNetworkCapabilities(network)
+
+    return networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/MyApplication.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/MyApplication.kt
@@ -13,6 +13,7 @@ import ar.teamrocket.duelosmeli.data.repository.impl.MeliRepositoryImpl
 import ar.teamrocket.duelosmeli.data.repository.impl.PlayersRepositoryImpl
 import ar.teamrocket.duelosmeli.domain.GameFunctions
 import ar.teamrocket.duelosmeli.domain.impl.GameFunctionsImpl
+import ar.teamrocket.duelosmeli.ui.singleplayerActivities.viewModels.MainMenuViewModel
 import ar.teamrocket.duelosmeli.ui.duelActivities.DuelGameViewModel
 import ar.teamrocket.duelosmeli.ui.multiplayerActivities.viewModels.MultiplayerGamePartialResultActivityViewModel
 import ar.teamrocket.duelosmeli.ui.multiplayerActivities.viewModels.MultiplayerGameReadyViewModel
@@ -36,6 +37,7 @@ class MyApplication : Application() {
         viewModel { NewMultiplayerGameViewModel(get()) }
         viewModel { MultiplayerGameViewModel(get(), get()) }
         viewModel { DuelGameViewModel() }
+        viewModel { MainMenuViewModel(get()) }
 
         single<MeliRepository> { MeliRepositoryImpl() }
         single<GameFunctions> { GameFunctionsImpl() }

--- a/app/src/main/java/ar/teamrocket/duelosmeli/data/model/CategoriesList.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/data/model/CategoriesList.kt
@@ -1,0 +1,9 @@
+package ar.teamrocket.duelosmeli.data.model
+
+/**
+ * Este Singleton va a mantener la lista de categorias durante todo el ciclo de vida de la app.
+ * Nos permite poder usar la lista en cualquier modo de juego,
+ */
+object CategoriesList {
+    lateinit var categoriesList: List<Category>
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/data/model/Language.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/data/model/Language.kt
@@ -1,0 +1,34 @@
+package ar.teamrocket.duelosmeli.data.model
+
+import java.util.*
+
+/**
+ * En principio vamos a manejar un solo idioma en la app (entre español o portugues)
+ * que se va a determinar de acuerdo al idioma que tenga configurado el usuario
+ * en su dispositivo (como viene siendo hasta ahora), pero para más adelante
+ * podríamos permitir que la configuración del idioma se maneje desde la app, y con este
+ * Singleton lo hacemos escalable a esa posibilidad.
+ */
+object Language {
+
+    val language: Locale = Locale.getDefault()
+
+    /**
+     * En base al [language] que tenga configurado el usuario en su dispositivo, tenemos el país
+     * por el cual vamos a tener en cuenta las configuraciones de traducción y APIs
+     * @return [Country] se retorna un país de entre los que tenemos en el enum
+     */
+    fun getAvailableLanguageCountry(): Country{
+        return when (language.toLanguageTag()) {
+            "pt-BR", "pt-PT" -> Country.BRASIL
+            else -> Country.ARGENTINA
+        }
+    }
+}
+
+/**
+ * Paises que estamos teniendo en cuenta para las configuraciones de la app
+ */
+enum class Country {
+    ARGENTINA, BRASIL
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/GenericMaterialDialog.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/GenericMaterialDialog.kt
@@ -1,0 +1,75 @@
+package ar.teamrocket.duelosmeli.ui
+
+import android.content.Context
+import ar.teamrocket.duelosmeli.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * Clase para construir dialogs de Material Design de acuerdo a como querramos configurarlos
+ * De no encontrar un constructor adecuado para algún requerimiento, agregarlo
+ */
+class GenericMaterialDialog {
+    val context: Context
+    val title: Int
+    val message: Int?
+    val negativeButton: Int?
+    val positiveButton: Int?
+    val negativeFun: (() -> Unit)?
+    val positiveFun: (() -> Unit)?
+
+    /**
+     * Constructor completo con todos los parametros
+     * @param [context] contexto de la activity
+     * @param [title] titulo
+     * @param [message] descripción
+     *
+     * Los botones no necesariamente deben estar relacionado a una acción "negativa" o "positiva"
+     * @param [negativeButton] texto del botón
+     * @param [positiveButton] texto del botón
+     * @param [negativeFun] se recibe una función para ejecutar con el botón
+     * @param [positiveFun] se recibe una función para ejecutar con el botón
+     */
+    constructor(context: Context, title: Int, message: Int, negativeButton: Int, positiveButton: Int, negativeFun: (() -> Unit), positiveFun: (() -> Unit)) {
+        this.context = context
+        this.title = title
+        this.message = message
+        this.negativeButton = negativeButton
+        this.positiveButton = positiveButton
+        this.negativeFun = negativeFun
+        this.positiveFun = positiveFun
+    }
+
+    constructor(context: Context, title: Int) {
+        this.context = context
+        this.title = title
+        this.message = null
+        this.negativeButton = null
+        this.positiveButton = null
+        this.negativeFun = null
+        this.positiveFun = null
+    }
+
+    /**
+     * Construye el dialog de acuerdo al constructor que se utilice
+     */
+    fun buildDialog() {
+        val builder = MaterialAlertDialogBuilder(context, R.style.Dialog)
+            .setTitle(title)
+
+        message?.let { builder.setMessage(it) }
+
+        negativeButton?.let {
+            builder.setNegativeButton(it) { _, _ ->
+                negativeFun?.invoke()
+            }
+        }
+
+        positiveButton?.let {
+            builder.setPositiveButton(it) { _, _ ->
+                positiveFun?.invoke()
+            }
+        }
+
+        builder.show()
+    }
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/ListActivity.kt
@@ -139,5 +139,6 @@ class ListActivity : ComponentActivity() {
         intent.putExtra("Points", pointsAchieved)
         intent.putExtra("IdPlayer", idPlayer)
         startActivity(intent)
+        finish()
     }
 }

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/multiplayerActivities/viewModels/MultiplayerGameViewModel.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/multiplayerActivities/viewModels/MultiplayerGameViewModel.kt
@@ -3,6 +3,8 @@ package ar.teamrocket.duelosmeli.ui.multiplayerActivities.viewModels
 import androidx.lifecycle.*
 import ar.teamrocket.duelosmeli.data.database.Multiplayer
 import ar.teamrocket.duelosmeli.data.model.Article
+import ar.teamrocket.duelosmeli.data.model.CategoriesList
+import ar.teamrocket.duelosmeli.data.model.Category
 import ar.teamrocket.duelosmeli.data.repository.MeliRepository
 import ar.teamrocket.duelosmeli.data.repository.PlayersRepository
 import ar.teamrocket.duelosmeli.domain.GameMultiplayer
@@ -21,13 +23,13 @@ class MultiplayerGameViewModel(val meliRepositoryImpl: MeliRepository, var repos
     var currentPlayer = MutableLiveData<Multiplayer>()
     var playersOrderByScore = MutableLiveData<List<Multiplayer>>()
     var team = MutableLiveData<List<Multiplayer>>()
+    private val categories: List<Category> = CategoriesList.categoriesList
 
 
     fun findCategories() {
         viewModelScope.launch {
             starGame.value = false
             try {
-                val categories = meliRepositoryImpl.searchCategories()
                 val categoryId = categories[(categories.indices).random()].id
                 findItemFromCategory(categoryId)
 

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/GameViewModel.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/GameViewModel.kt
@@ -4,11 +4,7 @@ import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import ar.teamrocket.duelosmeli.data.model.Article
-import ar.teamrocket.duelosmeli.data.model.Articles
-import ar.teamrocket.duelosmeli.data.model.Category
-import ar.teamrocket.duelosmeli.data.model.ItemDuel
-import ar.teamrocket.duelosmeli.data.model.ItemPlayed
+import ar.teamrocket.duelosmeli.data.model.*
 import ar.teamrocket.duelosmeli.data.preferences.Prefs
 import ar.teamrocket.duelosmeli.data.repository.MeliRepository
 import kotlinx.coroutines.launch
@@ -17,11 +13,10 @@ import java.text.NumberFormat
 import java.util.*
 import kotlin.math.roundToInt
 
-
 class GameViewModel (val meliRepositoryImpl : MeliRepository, private val prefs: Prefs) : ViewModel() {
 
     private val systemLanguage: String = Locale.getDefault().language
-    private lateinit var categories: List<Category>
+    private val categories: List<Category> = CategoriesList.categoriesList
     private lateinit var categoryId: String
     lateinit var items: Articles
     val itemNameMutable = MutableLiveData<String>()
@@ -48,10 +43,6 @@ class GameViewModel (val meliRepositoryImpl : MeliRepository, private val prefs:
         viewModelScope.launch {
             starGame.value = false
             try {
-                categories = when(systemLanguage) {
-                    "pt" -> meliRepositoryImpl.searchCategoriesBR()
-                    else -> meliRepositoryImpl.searchCategories()
-                }
                 categoryId = categories[(categories.indices).random()].id
                 findItemFromCategory(categoryId)
 

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/MainMenuViewModel.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/viewModels/MainMenuViewModel.kt
@@ -1,0 +1,49 @@
+package ar.teamrocket.duelosmeli.ui.singleplayerActivities.viewModels
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ar.teamrocket.duelosmeli.httpStatusHandler
+import ar.teamrocket.duelosmeli.data.model.CategoriesList
+import ar.teamrocket.duelosmeli.data.model.Category
+import ar.teamrocket.duelosmeli.data.model.Country
+import ar.teamrocket.duelosmeli.data.model.Language
+import ar.teamrocket.duelosmeli.data.repository.MeliRepository
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.net.UnknownHostException
+
+/**
+ * ViewModel del MainMenu (screen de selección de modos de juego)
+ * @param [meliRepositoryImpl] clase que implementa la interfaz [MeliRepository]]
+ * Por inyección de dependencias le pasamos [MeliRepositoryImpl], que hace las llamadas a las APIs
+ */
+class MainMenuViewModel(val meliRepositoryImpl : MeliRepository) : ViewModel() {
+
+    val availableLanguage = Language.getAvailableLanguageCountry()
+    val categoriesException = MutableLiveData<Throwable>()
+    lateinit var categories: List<Category>
+
+    /**
+     * Llamamos a la API de categorias correspondiente al pais que consideramos para la
+     * configuración de la app. Guardamos la lista de categorías en el Singleton [CategoriesList]
+     */
+    fun searchCategories() {
+        viewModelScope.launch {
+            try {
+                categories = when (availableLanguage) {
+                    Country.ARGENTINA -> meliRepositoryImpl.searchCategories()
+                    Country.BRASIL -> meliRepositoryImpl.searchCategoriesBR()
+                }
+
+                CategoriesList.categoriesList = categories
+
+            } catch (e: Exception) {
+                when (e) {
+                    is HttpException -> httpStatusHandler(e)
+                    is UnknownHostException -> categoriesException.value = e
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/NewGameActivity.kt
+++ b/app/src/main/java/ar/teamrocket/duelosmeli/ui/singleplayerActivities/views/NewGameActivity.kt
@@ -24,7 +24,10 @@ class NewGameActivity : AppCompatActivity() {
         setContentView(binding.root)
 
     binding.iHeader.tvTitle.text=getString(R.string.player)
-    binding.iHeader.ivButtonBack.setOnClickListener { onBackPressed() }
+    binding.iHeader.ivButtonBack.setOnClickListener {
+        onBackPressed()
+        finish()
+    }
 
 
     //Obtengo todos los jugadores guardados
@@ -55,6 +58,7 @@ class NewGameActivity : AppCompatActivity() {
                     val idLastPlayer = allPlayers.size+1 //Calculamos cual es el ID que se autogeneró
                     val player = playerDao.getById(idLastPlayer.toLong()) // obtengo el nuevo jugador desde la DB.
                     viewGame(player)
+                    finish()
                 }
             }
         }
@@ -76,6 +80,7 @@ class NewGameActivity : AppCompatActivity() {
         super.onBackPressed()
         val intent = Intent(this, MainMenuActivity::class.java)
         startActivity(intent)
+        finish()
     }
 
 }

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -54,4 +54,7 @@
     <string name="acerca_de">Sobre duelosMeli</string>
     <string name="_1_jugador">1 JOGADOR</string>
     <string name="multijugador">MULTIJOGADOR</string>
+    <string name="revisar_conexion">Verifique se você está conectado a uma rede Wi-Fi com conexão à Internet ou rede de dados móveis. Ainda não temos um modo de jogo offline :(</string>
+    <string name="salir">Sair</string>
+    <string name="sin_internet">Opa! Parece que você não tem internet</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,9 +38,12 @@
     <string name="money_sign" translatable="false">$</string>
     <string name="delete">Borrar</string>
     <string name="conexion_perdida">Se ha perdido la conexión a internet</string>
+    <string name="sin_internet">¡Ups! Parece que no tenés internet</string>
     <string name="asegurar_conexion">Asegurate de estar conectado a una red Wi-Fi con conexión a internet o red de datos móviles</string>
+    <string name="revisar_conexion">Asegurate de estar conectado a una red Wi-Fi con conexión a internet o red de datos móviles. Todavía no tenemos un modo de juego offline :(</string>
     <string name="terminar_partida">Terminar la partida</string>
     <string name="reintentar_conexion">Reintentar conexión</string>
+    <string name="salir">Salir</string>
     <string name="partida_finalizada">Partida finalizada</string>
     <string name="player">Jugador</string>
     <string name="partida_multijugador">Partida multijugador</string>


### PR DESCRIPTION
<!--- Escribir un resumen de los cambios -->
Se requiere desacoplar la búsqueda de categorías, que actualmente se encontraba “pegada” a cada modo de juego.

## Motivación y contexto
<!--- Motivo del cambio. ¿Qué problema resuelve? -->
Por como tenemos el código actualmente estamos haciendo la llamada a la API de categorías en cada modo de juego cada vez que necesitamos buscar un producto.
Con este refactor dejamos de hacer tantas llamadas innecesarias para buscar todo el tiempo las categorías. Las buscamos una sola vez (o se intenta buscarlas las veces que sean necesarias en caso de no contar con conexión a internet) y las guardamos en una lista para poder reutilizarlas desde allí.

## Descripción
<!--- Describir los cambios en detalle -->
Con este refactor hacemos la llamada a la API al entrar a MainMenuActivity y guardamos las categorias en una lista que queda en un Singleton. De esta manera hacemos solo una vez la llamada a la API de categorías y podemos reutilizarlas desde la lista mientras permanezca vivo todo el ciclo de vida de la app.

Esta tarea implicó también:
- Tener una función que nos brinde el país por el cual vamos a hacer la llamada a la API de categorías y las traducciones.
- Verificar que el usuario tenga acceso de internet al momento de querer usar la aplicación. Si tiene, continua el flujo de la app normalmente, si no tiene, se le pide que intente conectarse o sino no podrá utilizar la app.

Para esto se requirió:
1. Una función que chequee si el dispositivo cuenta con conexión a internet.
2. Lanzar dialogs correspondientes a cada situación.

## Cómo probarlo
<!--- Bug fixes: describir cómo reproducir el comportamiento que generaba el bug -->
<!--- Nuevos features: describir qué función de la app probar -->
Algunas formas de probarlo pueden ser:
1. Iniciar el juego sin conexión a internet. y probar los botones del dialog, los de los modos de juego, el de localización.
2. Con el dialog en vista, conectar el dispositivo a internet y tocar en el botón de reintentar, jugar una partida, terminarla, desconectar internet y volver al inicio.

### **Aclaración**
No va a pasar que en cada activity si de repente te quedas sin internet se lance el modal. Creo que para eso necesitaríamos implementar un Broadcast Receiver, que creo que funciona como un Listener que escucha todo el tiempo algo que le configures. Pero desconozco como funciona eso por el momento y ya se escapaba del scope de esta feature.

Con esta feature nos cubrimos un poco de crashear más que nada por querer usar la app sin internet.

## Screenshots
<!--- Bug fixes: comparativa de antes y después (screenshots o videos) -->
<!--- Nuevos features: screenshots de la nueva UI -->
### Dialog en ambos idiomas - ES-PR
Español | Portugués
---------|---------
<img width="251" alt="spanish" src="https://github.com/MuiaLeandro/duelosMeli/assets/49699988/6b50b67c-e3ab-42ad-acf5-cb543f1af9d5"> | <img width="251" alt="brazilian" src="https://github.com/MuiaLeandro/duelosMeli/assets/49699988/20ebf613-de3f-44cc-9c1d-fec4d6ee336d">


## Compartir conocimiento
<!--- Compartir links a blogs, patrones, librerías que se usaron para resolver el problema o desarrollar la nueva feature -->
[Material Design Dialogs](https://m2.material.io/components/dialogs/android#using-dialogs)
[Locale -> getDefault. Función para tener el idioma que tiene configurado el dispositivo del usuario](https://developer.android.com/reference/java/util/Locale#getDefault())
[Lista de status codes HTTP](https://www.semrush.com/blog/http-status-codes/?kw=&cmp=LM_SRCH_DSA_Blog_EN&label=dsa_pagefeed&Network=g&Device=c&utm_content=665415191890&kwid=dsa-2147915054147&cmpid=18364824154&agpid=150763690266&BU=Core&extid=91683961363&adpos=&gclid=CjwKCAjwxaanBhBQEiwA84TVXJlpmOauavSEDOv-cFqjol2P00DfeVhH64VitcHK115Y9NZx6N4trBoC6E0QAvD_BwE)
